### PR TITLE
Library for parsing Github on-boarding markdown requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @keyko-io/filecoin-doers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keyko-io/filecoin-verifier-tools",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/samples/utils/datacap_request.test.md
+++ b/samples/utils/datacap_request.test.md
@@ -1,0 +1,57 @@
+---
+name: Request Datacap
+about: Users must open a new issue to request datacap for their addresses
+title: 'Data Cap Request for: [Organization Name]'
+labels: 'state:Request'
+assignees: ''
+
+---
+
+##  Datacap Request Information
+
+Please complete the following information:
+
+### Organization Name
+
+>Protocol Labs
+
+Please replace `Protocol Labs` with your Organization or personal name
+
+### Address
+
+>t0231874218
+
+Please replace `t0231874218` with your Filecoin address
+
+### Datacap Requested
+
+>10TB
+
+Please, use the (GB, TB, HB, ..) format.
+
+## Additional Information
+
+Is there any other information you can provide?
+
+### Public Profile of Organization
+
+Some description or link to the public profile of the organization
+
+### Intended Use Case / Allocation Plan
+
+Please, include some information about the main usage you want to make of the datacap.
+
+### Contact Information
+
+How can we contact with you?
+
+### Comments
+
+Do you have any additional comment?
+
+
+## Disclaimer
+
+Be aware that the information you are submitting will be publicly available for all Filecoin community and it could be used to oversight and trace the verify flows.
+
+###### _Note: If you are not familiar with markdown language, use the Preview tab to make sure the form is properly filled._

--- a/utils/issue-parser.js
+++ b/utils/issue-parser.js
@@ -1,0 +1,46 @@
+
+
+function parseIssue(issueContent)  {
+  const regexName = /###\s*Organization\sName\n\n^>\s*(.*)/m
+  const regexAddress = /###\s*Address\n\n^>\s*(.*)/m
+  const regexDatacap = /###\s*Datacap\sRequested\n\n^>\s*(.*)/m
+  const regexInfo = /##\s*Additional\sInformation([\s\S]*)##\sDisclaimer/gm
+
+  const name = matchGroup(regexName, issueContent)
+  const address = matchGroup(regexAddress, issueContent)
+  const datacap = matchGroup(regexDatacap, issueContent)
+  const additionalInfo = matchGroup(regexInfo, issueContent)
+
+  if (name != null && address != null && datacap != null && additionalInfo != null)
+    return {
+      correct: true,
+      errorMessage: '',
+      name: name,
+      address: address,
+      datacap: datacap,
+      additionalInformation: additionalInfo
+    }
+
+  return {
+    correct: false,
+    errorMessage: `Unable to find required attributes.
+      Found: name= ${name},
+      address= ${address},
+      datacap= ${datacap},
+      additionalInformation= ${additionalInfo}`
+  }
+}
+
+
+
+function matchGroup(regex, content) {
+  let m
+  if ((m = regex.exec(content)) !== null) {
+      if (m.length >=1)
+        return m[1]
+  }
+  return
+}
+
+
+exports.parseIssue = parseIssue

--- a/utils/issue-parser.js
+++ b/utils/issue-parser.js
@@ -1,6 +1,5 @@
 
-
-function parseIssue(issueContent)  {
+function parseIssue(issueContent) {
   const regexName = /###\s*Organization\sName\n\n^>\s*(.*)/m
   const regexAddress = /###\s*Address\n\n^>\s*(.*)/m
   const regexDatacap = /###\s*Datacap\sRequested\n\n^>\s*(.*)/m
@@ -11,15 +10,16 @@ function parseIssue(issueContent)  {
   const datacap = matchGroup(regexDatacap, issueContent)
   const additionalInfo = matchGroup(regexInfo, issueContent)
 
-  if (name != null && address != null && datacap != null && additionalInfo != null)
+  if (name != null && address != null && datacap != null && additionalInfo != null) {
     return {
       correct: true,
       errorMessage: '',
       name: name,
       address: address,
       datacap: datacap,
-      additionalInformation: additionalInfo
+      additionalInformation: additionalInfo,
     }
+  }
 
   return {
     correct: false,
@@ -27,20 +27,15 @@ function parseIssue(issueContent)  {
       Found: name= ${name},
       address= ${address},
       datacap= ${datacap},
-      additionalInformation= ${additionalInfo}`
+      additionalInformation= ${additionalInfo}`,
   }
 }
-
-
 
 function matchGroup(regex, content) {
   let m
   if ((m = regex.exec(content)) !== null) {
-      if (m.length >=1)
-        return m[1]
+    if (m.length >= 1) { return m[1] }
   }
-  return
 }
-
 
 exports.parseIssue = parseIssue

--- a/utils/issue-parser.test.js
+++ b/utils/issue-parser.test.js
@@ -1,0 +1,26 @@
+var fs = require('fs')
+var path = require('path')
+const { parseIssue } = require('./issue-parser')
+
+describe('parseIssue()', () => {
+  it('we can parse an issue including the right data', () => {
+
+    const issueContent = fs.readFileSync(
+      path.resolve(__dirname, '../samples/utils/datacap_request.test.md'),
+      { encoding: 'utf8' }
+    )
+    const parsedResult = parseIssue(issueContent)
+
+    expect(parsedResult.correct).toBe(true)
+    expect(parsedResult.name).toBe('Protocol Labs')
+    expect(parsedResult.address).toBe('t0231874218')
+    expect(parsedResult.datacap).toBe('10TB')
+    expect(parsedResult.additionalInformation).toContain('Is there any other information you can provide')
+  })
+
+  it('we can not parse an invalid issue', () => {
+    const parsedResult = parseIssue('random string')
+    expect(parsedResult.correct).toBe(false)
+    expect(parsedResult.errorMessage).not.toBe('')
+  })
+})

--- a/utils/issue-parser.test.js
+++ b/utils/issue-parser.test.js
@@ -4,10 +4,9 @@ const { parseIssue } = require('./issue-parser')
 
 describe('parseIssue()', () => {
   it('we can parse an issue including the right data', () => {
-
     const issueContent = fs.readFileSync(
       path.resolve(__dirname, '../samples/utils/datacap_request.test.md'),
-      { encoding: 'utf8' }
+      { encoding: 'utf8' },
     )
     const parsedResult = parseIssue(issueContent)
 


### PR DESCRIPTION
Adding a library for parsing the Markdown content related with a Github Client Datacap on-boarding request/

This functionality can be used in the frontend to parse the input given by the users
implements #46