### PR TITLE
parseReleaseRequest function update

### DIFF
--- a/utils/large-issue-parser.js
+++ b/utils/large-issue-parser.js
@@ -226,6 +226,7 @@ function parseReleaseRequest(commentContent) {
   const notaryAddress = matchGroup(regexNotaryAddress, commentContent)
   const clientAddress = matchGroup(regexClientAddress, commentContent)
   const allocationDatacap = matchGroup(regexAllocationDatacap, commentContent)
+  const allocationDataCapAmount = matchAll(regexAllocationDatacap, commentContent)
 
   if (notaryAddress != null && clientAddress != null && allocationDatacap != null) {
     return {
@@ -234,6 +235,7 @@ function parseReleaseRequest(commentContent) {
       notaryAddress: notaryAddress,
       clientAddress: clientAddress,
       allocationDatacap: allocationDatacap,
+      allocationDataCapAmount: allocationDataCapAmount
     }
   }
 

--- a/utils/large-issue-parser.js
+++ b/utils/large-issue-parser.js
@@ -235,7 +235,7 @@ function parseReleaseRequest(commentContent) {
       notaryAddress: notaryAddress,
       clientAddress: clientAddress,
       allocationDatacap: allocationDatacap,
-      allocationDataCapAmount: allocationDataCapAmount
+      allocationDataCapAmount: allocationDataCapAmount,
     }
   }
 


### PR DESCRIPTION
Added allocationDataCapAmount to the parseReleaseRequest function's return statement. This returns a substring with only the amount requested instead of the whole string.