### PR TITLE
Remove datacap methods

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -66,6 +66,21 @@ class VerifyAPI {
     return res['/']
   }
 
+  async proposeRemoveDataCap(clientToRemoveDcFrom, datacap, verifier1, signature1, verifier2, signature2, indexAccount, wallet, { gas } = { gas: 0 }) {
+    const removeDatacapProposal =  this.methods.verifreg.removeVerifiedClientDataCap(
+          clientToRemoveDcFrom,datacap,
+          {verifier:verifier1, signature:signature1},
+          {verifier:verifier2, signature:signature2}
+        )
+    const tx = this.methods.rootkey.propose(removeDatacapProposal)
+    const res = await this.methods.sendTx(this.client, indexAccount, this.checkWallet(wallet), { ...tx, gas })
+    return res['/']
+  }
+
+  // async approveRemoveDataCap(msig, tx, from, wallet) {
+  // return await this.approvePending(msig, tx, from, wallet)
+  // }
+
   async proposeRemoveVerifier(verifierAccount, indexAccount, wallet, { gas } = { gas: 0 }) {
     // Not address but account in the form "t01004", for instance
     const tx = this.methods.rootkey.propose(this.methods.verifreg.removeVerifier(verifierAccount))
@@ -340,34 +355,6 @@ class VerifyAPI {
     }
   }
 
-  async signRemoveDataCapProposal(sender, msig, datacap) {
-    // console.log('started must specify notary address, client address, and allowance to remove')
-    try {
-      const arr = this.methods.encodeSignRemoveDataCapProposal(sender, msig, datacap)
-      console.log('after building object:', arr)
-
-      const signed = await this.client.walletSign('t0101', arr) // t0101 to change --> it is the --from param
-      console.log('signed object:', signed)
-
-      // 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'
-      console.log('buuferfrom', Buffer.from(signed.Data, 'base64'))
-
-      const b = Buffer.from(signed.Data, 'base64')
-
-      const signedBytesArr = new TextEncoder().encode(b)
-
-      const toHex = toHexString(signedBytesArr)
-
-      return new TextEncoder().encode(signed.Type) + toHex
-
-      // RESULT: 494631326835456b6f3051344349647350544248423870334d505772774477494838384b463938357359496b535a3962392b587653432b426948364c33357a646145426f32386d67734545502b35546f4f317a69683041453d
-      // testing in the lotus node with the same parameters I receive:
-      // 010c13af22c43e49d044dd9c147629fa21a86709d720154181f358210d162c78df4b803d2e82d3aae8320e812cc0a6a68ce8e68737482f21f70d2684c7f9619cb301
-      // not sure how should encode-decode the object
-    } catch (error) {
-      console.log(error)
-    }
-  }
 
   async listMessagesFromToAddress(From, To, heightPerc = 0.5) {
     try {

--- a/api/api.js
+++ b/api/api.js
@@ -4,7 +4,6 @@ const { BrowserProvider } = require('@filecoin-shipyard/lotus-client-provider-br
 const { NodejsProvider } = require('@filecoin-shipyard/lotus-client-provider-nodejs')
 const { LotusRPC } = require('@filecoin-shipyard/lotus-client-rpc')
 const cbor = require('cbor')
-const { toHexString } = require('multihashes/src/')
 
 const cacheAddress = {}
 const cacheKey = {}
@@ -67,11 +66,11 @@ class VerifyAPI {
   }
 
   async proposeRemoveDataCap(clientToRemoveDcFrom, datacap, verifier1, signature1, verifier2, signature2, indexAccount, wallet, { gas } = { gas: 0 }) {
-    const removeDatacapProposal =  this.methods.verifreg.removeVerifiedClientDataCap(
-          clientToRemoveDcFrom,datacap,
-          {verifier:verifier1, signature:signature1},
-          {verifier:verifier2, signature:signature2}
-        )
+    const removeDatacapProposal = this.methods.verifreg.removeVerifiedClientDataCap(
+      clientToRemoveDcFrom, datacap,
+      { verifier: verifier1, signature: signature1 },
+      { verifier: verifier2, signature: signature2 },
+    )
     const tx = this.methods.rootkey.propose(removeDatacapProposal)
     const res = await this.methods.sendTx(this.client, indexAccount, this.checkWallet(wallet), { ...tx, gas })
     return res['/']
@@ -354,7 +353,6 @@ class VerifyAPI {
       return { success: false, error }
     }
   }
-
 
   async listMessagesFromToAddress(From, To, heightPerc = 0.5) {
     try {

--- a/filecoin/methods.js
+++ b/filecoin/methods.js
@@ -284,7 +284,7 @@ function make(testnet) {
     if (schema === 'bigint-key') {
       return encodeBigKey(data)
     }
-    if (schema === 'int' || typeof data === 'string') {
+    if (schema === 'int' || typeof data === 'string' && schema !== 'signature') {
       return parseInt(data)
     }
     if (schema === 'int' || schema === 'buffer') {
@@ -514,6 +514,12 @@ function make(testnet) {
     clients: ['ref', table],
   }
 
+  const REMOVE_DATACAP_PROPOSAL = {
+    removalProposalID: 'bigint',
+    datacapAmount: 'bigint',
+    verifiedClient: 'address',
+  }
+
   const reg = {
     t080: multisig,
     t06: verifreg,
@@ -572,6 +578,9 @@ function make(testnet) {
     ROOTKEY,
     VERIFREG,
     INIT_ACTOR,
+    RemoveDataCapProposal: REMOVE_DATACAP_PROPOSAL,
+    
+
   }
 }
 

--- a/filecoin/methods.js
+++ b/filecoin/methods.js
@@ -610,7 +610,22 @@ function make(testnet) {
         cap: 'bigint',
       },
     },
+    7: {
+      name: 'removeVerifiedClientDataCap',
+      input: {
+        address: 'address',
+        cap: 'bigint',
+        verifierRequest1 : 'buffer',
+        verifierRequest2 : 'buffer',
+      },
+    },
   }
+
+  /*
+  VerifiedClientToRemove addr.Address
+	DataCapAmountToRemove  DataCap
+	VerifierRequest1       RemoveDataCapRequest
+	VerifierRequest2       RemoveDataCapRequest*/
 
   const table = {
     type: 'hamt',

--- a/filecoin/methods.js
+++ b/filecoin/methods.js
@@ -23,148 +23,12 @@ function make(testnet) {
     return Buffer.from((address.newFromString(str)).str, 'binary')
   }
 
-  /*
-
-  function min(a, b) {
-    if (a < b) return a
-    else return b
-  }
-
-  function max(a, b) {
-    if (a > b) return a
-    else return b
-  }
-
-  const gasOveruseNum = 11n
-  const gasOveruseDenom = 10n
-
-  function computeGasToBurn(gasUsed, gasLimit) {
-    if (gasUsed === 0n) {
-      return gasLimit
-    }
-
-    // over = gasLimit/gasUsed - 1 - 0.1
-    // over = min(over, 1)
-    // gasToBurn = (gasLimit - gasUsed) * over
-
-    // so to factor out division from `over`
-    // over*gasUsed = min(gasLimit - (11*gasUsed)/10, gasUsed)
-    // gasToBurn = ((gasLimit - gasUsed)*over*gasUsed) / gasUsed
-    const overuse = gasUsed * gasOveruseNum / gasOveruseDenom
-    let over = gasLimit - overuse
-
-    if (over < 0n) {
-      return 0n
-    }
-
-    if (over > gasUsed) {
-      over = gasUsed
-    }
-
-    return (gasLimit - gasUsed - over) / gasUsed
-  }
-
-  function gasCalcTxFee(
-    gasFeeCap,
-    gasPremium,
-    gasLimit,
-    baseFee,
-    gasUsed,
-  ) {
-    // compute left side
-    const totalGas = gasUsed + computeGasToBurn(gasUsed, gasLimit)
-    const minBaseFeeFeeCap = min(baseFee, gasFeeCap)
-    const leftSide = totalGas * minBaseFeeFeeCap
-
-    // compute right side
-    const minTip = min(gasFeeCap - baseFee, gasPremium)
-    const rightSide = gasLimit * max(0n, minTip)
-
-    return leftSide + rightSide
-  }
-
-  async function estimateGas(client, maxfee, { to, method, params, value, gas, nonce, from }) {
-    const head = await client.chainHead()
-    const baseFee = BigInt(head.Blocks[0].ParentBaseFee)
-
-    const estimation_msg = {
-      To: to,
-      From: from,
-      Nonce: nonce,
-      Value: value.toString() || '0',
-      GasFeeCap: '0',
-      GasPremium: '0',
-      GasLimit: gas || 0,
-      Method: method,
-      Params: params.toString('base64'),
-    }
-
-    const res = await client.gasEstimateMessageGas(estimation_msg, { MaxFee: maxfee.toString() }, head.Cids)
-    // console.log(res)
-
-    const msg = {
-      to: to,
-      from: from,
-      nonce: nonce,
-      value: value.toString() || '0',
-      gasfeecap: res.GasFeeCap,
-      gaspremium: res.GasPremium,
-      gaslimit: res.GasLimit,
-      method: method,
-      params: params,
-    }
-
-    const msg2 = { ...msg, params: params.toString('base64') }
-
-    const { ExecutionTrace: { MsgRct: { GasUsed } } } = await client.stateCall(msg2, head.Cids)
-    const fee = gasCalcTxFee(BigInt(res.GasFeeCap), BigInt(res.GasPremium), BigInt(res.GasLimit), baseFee, BigInt(GasUsed))
-    // console.log("got fee", fee)
-
-    return [msg, fee]
-  }
-
-  async function iterateGas(client, msg) {
-    let maxfee = BigInt(Math.pow(Number(BigInt(10)), Number(BigInt(10))))
-    let saved_error
-    const maxFeeComparison = BigInt(2) * BigInt(Math.pow(Number(BigInt(10)), Number(BigInt(18))))
-    while (maxfee < maxFeeComparison) {
-      try {
-        maxfee = maxfee * 2n
-        const [res, fee] = await estimateGas(client, maxfee, msg)
-        const ratio = 100n * fee / maxfee
-        console.log('fee', fee, 'max', maxfee, 'ratio', ratio)
-        if (ratio < 10n) {
-          return res
-        }
-      } catch (err) {
-        saved_error = err
-      }
-    }
-    throw saved_error
-  }
-  */
-
   async function signTx(client, indexAccount, walletContext, tx) {
     const head = await client.chainHead()
     const address = (await walletContext.getAccounts())[indexAccount]
 
-    // const state = await client.stateGetActor(address, head.Cids)
-    // let nonce = state.Nonce
     const nonce = await client.mpoolGetNonce(address)
     // console.log(nonce)
-    // const pending = await client.mpoolPending(head.Cids)
-    // for (const { Message: tx } of pending) {
-    //   if (tx.From === address && tx.Nonce + 1 > nonce) {
-    //     nonce = tx.Nonce + 1
-    //   }
-    // }
-    /*
-    console.log('Start estimnate gas...')
-    const msg = await iterateGas(client, { ...tx, from: address, nonce })
-    console.log('Estimate gas: ' + msg)
-
-    return walletContext.sign(msg, indexAccount)
-    */
 
     // OLD CODE WITH 0.1FIL HARDCODED MAXFEE
     const estimation_msg = {
@@ -194,8 +58,8 @@ function make(testnet) {
       method: tx.method,
       params: tx.params,
     }
-
-    return walletContext.sign(msg, indexAccount)
+    const sign = walletContext.sign(msg, indexAccount)
+    return sign
   }
 
   // returns tx hash
@@ -468,6 +332,18 @@ function make(testnet) {
     throw new Error(`Unknown type ${schema}`)
   }
 
+  function encodeSignRemoveDataCapProposal(notaryAddr, msigAddr, datacap) {
+    // console.log("signer.addressAsBytes('t01003')",signer.addressAsBytes('t01003'))
+
+    const notary = new TextEncoder().encode(Buffer.from(notaryAddr, 'base64'))
+    // const notary = new TextEncoder().encode(address.newFromString(notaryAddr).str)
+    const msig = new TextEncoder().encode(Buffer.from(msigAddr, 'base64'))
+    // const msig = new TextEncoder().encode(address.newFromString(msigAddr).str)
+    const dc = new TextEncoder().encode(Buffer.from(datacap, 'base64'))
+
+    return [...notary, ...msig, ...dc]
+  }
+
   function actor(address, spec) {
     const res = {}
     for (const [num, method] of Object.entries(spec)) {
@@ -624,17 +500,11 @@ function make(testnet) {
       input: {
         address: 'address',
         cap: 'bigint',
-        verifierRequest1 : 'buffer',
-        verifierRequest2 : 'buffer',
+        verifierRequest1: 'buffer',
+        verifierRequest2: 'buffer',
       },
     },
   }
-
-  /*
-  VerifiedClientToRemove addr.Address
-	DataCapAmountToRemove  DataCap
-	VerifierRequest1       RemoveDataCapRequest
-	VerifierRequest2       RemoveDataCapRequest*/
 
   const table = {
     type: 'hamt',
@@ -706,6 +576,7 @@ function make(testnet) {
     ROOTKEY,
     VERIFREG,
     INIT_ACTOR,
+    encodeSignRemoveDataCapProposal,
   }
 }
 

--- a/filecoin/methods.js
+++ b/filecoin/methods.js
@@ -296,12 +296,12 @@ function make(testnet) {
     if (schema === 'bool') {
       return data
     }
-    if (schema.type === 'hash' ) {
+    if (schema.type === 'hash') {
       const hashData = cborEncode(encode(schema.input, data))
       const hash = blake.blake2bHex(hashData, null, 32)
       return Buffer.from(hash, 'hex')
     }
-     if (schema === 'signature') {
+    if (schema === 'signature') {
       return Buffer.from(data, 'hex')
     }
     if (schema instanceof Array) {
@@ -335,7 +335,6 @@ function make(testnet) {
     throw new Error(`Unknown type ${schema}`)
   }
 
-
   function actor(address, spec) {
     const res = {}
     for (const [num, method] of Object.entries(spec)) {
@@ -356,7 +355,6 @@ function make(testnet) {
     }
     return res
   }
-
 
   const verifreg = {
     2: {
@@ -382,17 +380,17 @@ function make(testnet) {
       input: {
         verifiedClientToRemove: 'address',
         dataCapAmountToRemove: 'bigint',
-        verifierRequest1:{
-          verifier:'address',
-          signature: 'signature'
+        verifierRequest1: {
+          verifier: 'address',
+          signature: 'signature',
         },
-        verifierRequest2:{
-          verifier:'address',
-          signature: 'signature'
-        }
-        }
-      }
-    }
+        verifierRequest2: {
+          verifier: 'address',
+          signature: 'signature',
+        },
+      },
+    },
+  }
 
   const multisig = {
     3: {
@@ -504,7 +502,6 @@ function make(testnet) {
     pending: ['ref', pending],
   }
 
-
   const table = {
     type: 'hamt',
     key: 'address',
@@ -574,7 +571,7 @@ function make(testnet) {
     buildArrayData,
     ROOTKEY,
     VERIFREG,
-    INIT_ACTOR
+    INIT_ACTOR,
   }
 }
 

--- a/filecoin/methods.js
+++ b/filecoin/methods.js
@@ -296,10 +296,13 @@ function make(testnet) {
     if (schema === 'bool') {
       return data
     }
-    if (schema.type === 'hash') {
+    if (schema.type === 'hash' ) {
       const hashData = cborEncode(encode(schema.input, data))
       const hash = blake.blake2bHex(hashData, null, 32)
       return Buffer.from(hash, 'hex')
+    }
+     if (schema === 'signature') {
+      return Buffer.from(data, 'hex')
     }
     if (schema instanceof Array) {
       if (schema[0] === 'list') {
@@ -332,17 +335,6 @@ function make(testnet) {
     throw new Error(`Unknown type ${schema}`)
   }
 
-  function encodeSignRemoveDataCapProposal(notaryAddr, msigAddr, datacap) {
-    // console.log("signer.addressAsBytes('t01003')",signer.addressAsBytes('t01003'))
-
-    const notary = new TextEncoder().encode(Buffer.from(notaryAddr, 'base64'))
-    // const notary = new TextEncoder().encode(address.newFromString(notaryAddr).str)
-    const msig = new TextEncoder().encode(Buffer.from(msigAddr, 'base64'))
-    // const msig = new TextEncoder().encode(address.newFromString(msigAddr).str)
-    const dc = new TextEncoder().encode(Buffer.from(datacap, 'base64'))
-
-    return [...notary, ...msig, ...dc]
-  }
 
   function actor(address, spec) {
     const res = {}
@@ -354,7 +346,6 @@ function make(testnet) {
         } else {
           params = encode(method.input, data)
         }
-        // console.log("params", params)
         return {
           to: address,
           value: 0n,
@@ -365,6 +356,43 @@ function make(testnet) {
     }
     return res
   }
+
+
+  const verifreg = {
+    2: {
+      name: 'addVerifier',
+      input: {
+        verifier: 'address',
+        cap: 'bigint',
+      },
+    },
+    3: {
+      name: 'removeVerifier',
+      input: 'address',
+    },
+    4: {
+      name: 'addVerifiedClient',
+      input: {
+        address: 'address',
+        cap: 'bigint',
+      },
+    },
+    7: {
+      name: 'removeVerifiedClientDataCap',
+      input: {
+        verifiedClientToRemove: 'address',
+        dataCapAmountToRemove: 'bigint',
+        verifierRequest1:{
+          verifier:'address',
+          signature: 'signature'
+        },
+        verifierRequest2:{
+          verifier:'address',
+          signature: 'signature'
+        }
+        }
+      }
+    }
 
   const multisig = {
     3: {
@@ -476,35 +504,6 @@ function make(testnet) {
     pending: ['ref', pending],
   }
 
-  const verifreg = {
-    2: {
-      name: 'addVerifier',
-      input: {
-        verifier: 'address',
-        cap: 'bigint',
-      },
-    },
-    3: {
-      name: 'removeVerifier',
-      input: 'address',
-    },
-    4: {
-      name: 'addVerifiedClient',
-      input: {
-        address: 'address',
-        cap: 'bigint',
-      },
-    },
-    7: {
-      name: 'removeVerifiedClientDataCap',
-      input: {
-        address: 'address',
-        cap: 'bigint',
-        verifierRequest1: 'buffer',
-        verifierRequest2: 'buffer',
-      },
-    },
-  }
 
   const table = {
     type: 'hamt',
@@ -575,8 +574,7 @@ function make(testnet) {
     buildArrayData,
     ROOTKEY,
     VERIFREG,
-    INIT_ACTOR,
-    encodeSignRemoveDataCapProposal,
+    INIT_ACTOR
   }
 }
 

--- a/samples/api/encode-decode-params.js
+++ b/samples/api/encode-decode-params.js
@@ -1,0 +1,42 @@
+const VerifyAPI = require('../../api/api.js')
+const MockWallet = require('../mockWallet')
+const constants = require('../constants')
+const methods = require('../../filecoin/methods')
+const { acceleratedmobilepageurl } = require('googleapis/build/src/apis/acceleratedmobilepageurl')
+const { hex } = require('cbor/lib/utils')
+
+const endpointUrl = constants.lotus_endpoint
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.wpOIystriKCXuvbxQnMnYP8tNxgi3Uwn3yeBpeiZJtw'
+
+const rootkeyWallet = new MockWallet(constants.rootkey_mnemonic, constants.path)
+const verifiersWallet = new MockWallet(constants.verifier_mnemonic, constants.path)
+
+const api = new VerifyAPI(VerifyAPI.standAloneProvider(endpointUrl, {
+  token,
+}), verifiersWallet)
+
+async function removeDatacap() {
+  try {
+    const addressToRemoveDcFrom = 't01019'
+    const t06 = 't06'
+    const datacapToRemove = 1000
+
+    // console.log("methods:",methods)
+    // console.log("addressToRemoveDcFrom:",methods.testnet.encode('address',addressToRemoveDcFrom))
+    // console.log("t06encoded:",methods.testnet.encode('address',t06))
+    // console.log("datacapToRemove:", methods.testnet.encode('bigint',datacapToRemove))
+
+    const signature1 = '019c5b9cbdf04f8f33c9191601f4c444e146d426db192244555ef1f0e70037d5a52be9d27955823d00367fda28e729f3a56a30d348956edd6b74d204fc9d39f72c00'
+    const signature2 = '01e0868a38ced78ce20f2aca96506702fc5e7cb84b5a3b15ee40190eac7a202d1c3fdb0a2f391ea00190ae99094f39635ad8ced0fe96988945d8e14ed855840fa600'
+
+    // console.log("signature1:", methods.testnet.encode('signature',signature1))
+    console.log("signature1:", hex(signature1))
+
+    process.exit(0)
+    
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+removeDatacap()

--- a/samples/api/encode-decode-params.js
+++ b/samples/api/encode-decode-params.js
@@ -1,25 +1,23 @@
-const VerifyAPI = require('../../api/api.js')
-const MockWallet = require('../mockWallet')
-const constants = require('../constants')
-const methods = require('../../filecoin/methods')
-const { acceleratedmobilepageurl } = require('googleapis/build/src/apis/acceleratedmobilepageurl')
+// const VerifyAPI = require('../../api/api.js')
+// const MockWallet = require('../mockWallet')
+// const constants = require('../constants')
 const { hex } = require('cbor/lib/utils')
 
-const endpointUrl = constants.lotus_endpoint
-const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.wpOIystriKCXuvbxQnMnYP8tNxgi3Uwn3yeBpeiZJtw'
+// const endpointUrl = constants.lotus_endpoint
+// const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.wpOIystriKCXuvbxQnMnYP8tNxgi3Uwn3yeBpeiZJtw'
 
-const rootkeyWallet = new MockWallet(constants.rootkey_mnemonic, constants.path)
-const verifiersWallet = new MockWallet(constants.verifier_mnemonic, constants.path)
+// // const rootkeyWallet = new MockWallet(constants.rootkey_mnemonic, constants.path)
+// const verifiersWallet = new MockWallet(constants.verifier_mnemonic, constants.path)
 
-const api = new VerifyAPI(VerifyAPI.standAloneProvider(endpointUrl, {
-  token,
-}), verifiersWallet)
+// const api = new VerifyAPI(VerifyAPI.standAloneProvider(endpointUrl, {
+//   token,
+// }), verifiersWallet)
 
 async function removeDatacap() {
   try {
-    const addressToRemoveDcFrom = 't01019'
-    const t06 = 't06'
-    const datacapToRemove = 1000
+    // const addressToRemoveDcFrom = 't01019'
+    // const t06 = 't06'
+    // const datacapToRemove = 1000
 
     // console.log("methods:",methods)
     // console.log("addressToRemoveDcFrom:",methods.testnet.encode('address',addressToRemoveDcFrom))
@@ -27,13 +25,12 @@ async function removeDatacap() {
     // console.log("datacapToRemove:", methods.testnet.encode('bigint',datacapToRemove))
 
     const signature1 = '019c5b9cbdf04f8f33c9191601f4c444e146d426db192244555ef1f0e70037d5a52be9d27955823d00367fda28e729f3a56a30d348956edd6b74d204fc9d39f72c00'
-    const signature2 = '01e0868a38ced78ce20f2aca96506702fc5e7cb84b5a3b15ee40190eac7a202d1c3fdb0a2f391ea00190ae99094f39635ad8ced0fe96988945d8e14ed855840fa600'
+    // const signature2 = '01e0868a38ced78ce20f2aca96506702fc5e7cb84b5a3b15ee40190eac7a202d1c3fdb0a2f391ea00190ae99094f39635ad8ced0fe96988945d8e14ed855840fa600'
 
     // console.log("signature1:", methods.testnet.encode('signature',signature1))
-    console.log("signature1:", hex(signature1))
+    console.log('signature1:', hex(signature1))
 
     process.exit(0)
-    
   } catch (error) {
     console.log(error)
   }

--- a/samples/api/propose-remove-datacap.js
+++ b/samples/api/propose-remove-datacap.js
@@ -1,7 +1,6 @@
 const VerifyAPI = require('../../api/api.js')
 const MockWallet = require('../mockWallet')
 const constants = require('../constants')
-const { acceleratedmobilepageurl } = require('googleapis/build/src/apis/acceleratedmobilepageurl')
 
 const endpointUrl = constants.lotus_endpoint
 const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.wpOIystriKCXuvbxQnMnYP8tNxgi3Uwn3yeBpeiZJtw'
@@ -17,19 +16,18 @@ async function removeDatacap() {
   try {
     // const accounts = await verifiersWallet.getAccounts()
     // const rkAccounts = await rootkeyWallet.getAccounts()
-      // console.log('dc at start:', await api.checkClient('t01019'))
+    // console.log('dc at start:', await api.checkClient('t01019'))
     // console.log("accounts",rkAccounts)
     // process.exit(0)
 
     // get signature manually in test node using: lotus filplus sign-remove-data-cap-proposal t01004 t01019 600
     const signature1 = '0140c597d471f0856d7a81e9a090b25d46a8be1dc297e8e57f36471e7a37f4ffc40c7cff3c061bcad9e5feb53ed70e18a8cc5402f961a67df7802aef919d87fe9a01'
-    const signature2 = 
+    const signature2 =
     '01649f17c1e9212a4155d94b1a947416c9a98463d72f40d65602e6b003ff086a992b0090fb94b18e85f6f6145a932fe577b206de275ed1a73a3938d822d71b5cfd00'
 
-    const tx = await api.proposeRemoveDataCap('t01019', 1000, 't01004',signature1,'t01008',signature2, 2, rootkeyWallet)
-    console.log('TX:',tx)
+    const tx = await api.proposeRemoveDataCap('t01019', 1000, 't01004', signature1, 't01008', signature2, 2, rootkeyWallet)
+    console.log('TX:', tx)
     process.exit(0)
-    
   } catch (error) {
     console.log(error)
   }

--- a/samples/api/propose-remove-datacap.js
+++ b/samples/api/propose-remove-datacap.js
@@ -21,11 +21,11 @@ async function removeDatacap() {
     // process.exit(0)
 
     // get signature manually in test node using: lotus filplus sign-remove-data-cap-proposal t01004 t01019 600
-    const signature1 = '0140c597d471f0856d7a81e9a090b25d46a8be1dc297e8e57f36471e7a37f4ffc40c7cff3c061bcad9e5feb53ed70e18a8cc5402f961a67df7802aef919d87fe9a01'
+    const signature1 = '013c225da5e6380774ef85cdc47266513e148ea7a167cd9a45b3baecb157dd30030a1179cd2aeee464af5264e1111d08ab27047b8effc75a9e91c6aa6a98a3012100'
     const signature2 =
-    '01649f17c1e9212a4155d94b1a947416c9a98463d72f40d65602e6b003ff086a992b0090fb94b18e85f6f6145a932fe577b206de275ed1a73a3938d822d71b5cfd00'
+    '0175d8950d29fc5224a6d873fe25cc7b0745be263209bd3b643eb625b35a6bbe7d4fa46eb71fe526dd09e9580409e90e79c934450054442a7c593b8f4bbf27636000'
 
-    const tx = await api.proposeRemoveDataCap('t01019', 1000, 't01004', signature1, 't01008', signature2, 2, rootkeyWallet)
+    const tx = await api.proposeRemoveDataCap('t01019', 1000, 't01004', signature1, 't01001', signature2, 2, rootkeyWallet)
     console.log('TX:', tx)
     process.exit(0)
   } catch (error) {

--- a/samples/api/propose-remove-datacap.js
+++ b/samples/api/propose-remove-datacap.js
@@ -1,0 +1,38 @@
+const VerifyAPI = require('../../api/api.js')
+const MockWallet = require('../mockWallet')
+const constants = require('../constants')
+const { acceleratedmobilepageurl } = require('googleapis/build/src/apis/acceleratedmobilepageurl')
+
+const endpointUrl = constants.lotus_endpoint
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.wpOIystriKCXuvbxQnMnYP8tNxgi3Uwn3yeBpeiZJtw'
+
+const rootkeyWallet = new MockWallet(constants.rootkey_mnemonic, constants.path)
+const verifiersWallet = new MockWallet(constants.verifier_mnemonic, constants.path)
+
+const api = new VerifyAPI(VerifyAPI.standAloneProvider(endpointUrl, {
+  token,
+}), verifiersWallet)
+
+async function removeDatacap() {
+  try {
+    // const accounts = await verifiersWallet.getAccounts()
+    // const rkAccounts = await rootkeyWallet.getAccounts()
+      // console.log('dc at start:', await api.checkClient('t01019'))
+    // console.log("accounts",rkAccounts)
+    // process.exit(0)
+
+    // get signature manually in test node using: lotus filplus sign-remove-data-cap-proposal t01004 t01019 600
+    const signature1 = '0140c597d471f0856d7a81e9a090b25d46a8be1dc297e8e57f36471e7a37f4ffc40c7cff3c061bcad9e5feb53ed70e18a8cc5402f961a67df7802aef919d87fe9a01'
+    const signature2 = 
+    '01649f17c1e9212a4155d94b1a947416c9a98463d72f40d65602e6b003ff086a992b0090fb94b18e85f6f6145a932fe577b206de275ed1a73a3938d822d71b5cfd00'
+
+    const tx = await api.proposeRemoveDataCap('t01019', 1000, 't01004',signature1,'t01008',signature2, 2, rootkeyWallet)
+    console.log('TX:',tx)
+    process.exit(0)
+    
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+removeDatacap()

--- a/samples/api/wallet-sign-dc-removal-proposal.js
+++ b/samples/api/wallet-sign-dc-removal-proposal.js
@@ -1,0 +1,25 @@
+const VerifyAPI = require('../../api/api.js')
+const MockWallet = require('../mockWallet')
+const constants = require('../constants')
+
+const endpointUrl = constants.lotus_endpoint
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.wpOIystriKCXuvbxQnMnYP8tNxgi3Uwn3yeBpeiZJtw'
+
+const mockWallet = new MockWallet(constants.rootkey_mnemonic, constants.path)
+
+const api = new VerifyAPI(VerifyAPI.standAloneProvider(endpointUrl, {
+  token,
+}), mockWallet)
+
+async function tSignRemoveDataCapProposal() {
+  try {
+    // console.log('started must specify notary address, client address, and allowance to remove')
+    const res = await api.signRemoveDataCapProposal('t01004', 't01019', '600')
+    console.log('RESULT:', res)
+    process.exit(0)
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+tSignRemoveDataCapProposal()

--- a/samples/api/wallet-sign-dc-removal-proposal.js
+++ b/samples/api/wallet-sign-dc-removal-proposal.js
@@ -11,15 +11,19 @@ const api = new VerifyAPI(VerifyAPI.standAloneProvider(endpointUrl, {
   token,
 }), mockWallet)
 
-async function tSignRemoveDataCapProposal() {
+async function tsignDatacapRemoval() {
   try {
-    // console.log('started must specify notary address, client address, and allowance to remove')
-    const res = await api.signRemoveDataCapProposal('t01004', 't01019', '600')
-    console.log('RESULT:', res)
+    const rkAccounts = await mockWallet.getAccounts()
+    // console.log('accounts', rkAccounts)
+    // process.exit(0)
+
+    const res = await api.signDatacapRemoval('t01004', 1000, 't01019', mockWallet, 0)
+
+    console.log('RESULT SIGNATURE:', res)
     process.exit(0)
   } catch (error) {
     console.log(error)
   }
 }
 
-tSignRemoveDataCapProposal()
+tsignDatacapRemoval()


### PR DESCRIPTION
I’m trying to build an object and sign it in my app exactly like they do [here](https://github.com/filecoin-project/lotus/blob/422f66776fa07827f2cfa9d2f8142ef29dcd2a95/cli/filplus.go#L368)

### How do I encode parameters before signing them?

start testing from **tSignRemoveDataCapProposal**
in methods I'm building the object to be signed in ** encodeSignRemoveDataCapProposal**
** signRemoveDataCapProposal** is the main function
